### PR TITLE
Conserta no endpoint de /suporte/municipios/ o parâmetros de estado_sigla

### DIFF
--- a/app/controllers/municipios.py
+++ b/app/controllers/municipios.py
@@ -4,31 +4,20 @@ Municipios = municipios.Municipios
 from .response_pages.municipios import html as response_municipios
 from fastapi.responses import HTMLResponse
 
-def consulta_municipio(id_sus,municipio_nome,estado_sigla,estado_nome):
+def consulta_municipio(id_sus,municipio_nome_normalizado,municipio_nome,estado_sigla,estado_nome,estado_nome_normalizado):
     if estado_sigla != None : estado_sigla=estado_sigla.upper()
     params_full = {
+        # Aqui eu estou mantendo o municipio e estado normalizado aceitando o nome para não quebrar aplicações, mas deve ser substituido
         "municipio_id_sus":id_sus,
         "municipio_nome_normalizado":municipio_nome,
+        # "municipio_nome_normalizado":municipio_nome_normalizado,
         "estado_sigla":estado_sigla,
+        # "estado_nome_normalizado":estado_nome_normalizado,
         "estado_nome_normalizado":estado_nome,
     }
     params = {coluna:parametro for coluna, parametro in params_full.items() if parametro!=None}
     if len(params)==0: 
         query = session.query(Municipios)
-        res = query.all()
-        return res
-    elif params_full["estado_sigla"] != None or params_full["estado_nome_normalizado"] != None:
-        query = session.query(Municipios).with_entities(
-                    Municipios.id,
-                    Municipios.estado_sigla,
-                    Municipios.estado_nome,
-                    Municipios.estado_id_ibge,
-                    Municipios.municipio_eh_capital,
-                    Municipios.municipio_id_sus,
-                    Municipios.municipio_id_ibge,
-                    Municipios.municipio_nome,
-                    Municipios.municipio_nome_normalizado
-        ).filter_by(**params)
         res = query.all()
         return res
     else:

--- a/app/controllers/municipios.py
+++ b/app/controllers/municipios.py
@@ -4,7 +4,7 @@ Municipios = municipios.Municipios
 from .response_pages.municipios import html as response_municipios
 from fastapi.responses import HTMLResponse
 
-def consulta_municipio(id_sus,municipio_nome_normalizado,municipio_nome,estado_sigla,estado_nome,estado_nome_normalizado):
+def consulta_municipio(id_sus,municipio_nome,estado_sigla,estado_nome):
     if estado_sigla != None : estado_sigla=estado_sigla.upper()
     params_full = {
         # Aqui eu estou mantendo o municipio e estado normalizado aceitando o nome para não quebrar aplicações, mas deve ser substituido

--- a/app/routers/suporte.py
+++ b/app/routers/suporte.py
@@ -47,7 +47,7 @@ class User(BaseModel):
 # Os nomes normalizados devem ser separados do não normalizados. 
 # Por hora estou mantendo assim para não quebrar outras aplicações, mas será substituido.
 # async def consulta_municipio(id_sus: Optional[str] = None, municipio_nome_normalizado: Optional[str] = None , municipio_nome: Optional[str] = None , estado_sigla: Optional[str] = None, estado_nome_normalizado: Optional[str] = None, estado_nome: Optional[str] = None):
-async def consulta_municipio(id_sus: Optional[str] = None, municipio_nome_normalizado: Optional[str] =None, estado_sigla: Optional[str] = None, estado_nome: Optional[str] = None):
+async def consulta_municipio(id_sus: Optional[str] = None, municipio_nome: Optional[str] =None, estado_sigla: Optional[str] = None, estado_nome: Optional[str] = None):
     res = municipios.consulta_municipio(id_sus,municipio_nome,estado_sigla,estado_nome)
     return res
 

--- a/app/routers/suporte.py
+++ b/app/routers/suporte.py
@@ -44,7 +44,10 @@ class User(BaseModel):
     disabled: Optional[bool] = None
 
 @router.get("/suporte/municipios/", response_model=List[Municipio])
-async def consulta_municipio(id_sus: Optional[str] = None, municipio_nome: Optional[str] = None , estado_sigla: Optional[str] = None, estado_nome: Optional[str] = None):
+# Os nomes normalizados devem ser separados do não normalizados. 
+# Por hora estou mantendo assim para não quebrar outras aplicações, mas será substituido.
+# async def consulta_municipio(id_sus: Optional[str] = None, municipio_nome_normalizado: Optional[str] = None , municipio_nome: Optional[str] = None , estado_sigla: Optional[str] = None, estado_nome_normalizado: Optional[str] = None, estado_nome: Optional[str] = None):
+async def consulta_municipio(id_sus: Optional[str] = None, municipio_nome_normalizado: Optional[str] =None, estado_sigla: Optional[str] = None, estado_nome: Optional[str] = None):
     res = municipios.consulta_municipio(id_sus,municipio_nome,estado_sigla,estado_nome)
     return res
 


### PR DESCRIPTION
- Conserta problema de recebimento de estado por sigla.

Gera como issue:
- [A descriminação do endpoint de suporte de municipios descriminar nomes normalizados de não normalizados](https://github.com/ImpulsoGov/api-webapp/issues/42)