### PR TITLE
[Novos Usuários Resumo] Adiciona tratamento de erros do SQL Alchemy

### DIFF
--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from fastapi import HTTPException, Response
+from sqlalchemy import exc
 
 from app.models import db
 from app.models.saude_mental.perfildeusuarios import (
@@ -126,16 +127,26 @@ def obter_usuarios_novos(
 def obter_usuarios_novos_resumo(
     municipio_id_sus: str,
 ):
-    usuarios_novos_resumo = (
-        session.query(UsuariosNovosResumo)
-        .filter_by(unidade_geografica_id_sus=municipio_id_sus)
-        .all()
-    )
-
-    if len(usuarios_novos_resumo) == 0:
-        raise HTTPException(
-            status_code=404,
-            detail=("Dados usuarios resumo novos não encontrados."),
+    try:
+        usuarios_novos_resumo = (
+            session.query(UsuariosNovosResumo)
+            .filter_by(unidade_geografica_id_sus=municipio_id_sus)
+            .all()
         )
 
-    return usuarios_novos_resumo
+        if len(usuarios_novos_resumo) == 0:
+            raise HTTPException(
+                status_code=404,
+                detail=("Dados usuarios resumo novos não encontrados."),
+            )
+
+        return usuarios_novos_resumo
+    except exc.SQLAlchemyError as e:
+        session.rollback()
+
+        error = str(e.orig)
+
+        raise HTTPException(
+            status_code=500,
+            detail=(error),
+        )

--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -144,9 +144,11 @@ def obter_usuarios_novos_resumo(
     except exc.SQLAlchemyError as e:
         session.rollback()
 
-        error = str(e.orig)
+        error = str(e)
+
+        print({"error": error})
 
         raise HTTPException(
             status_code=500,
-            detail=(error),
+            detail=("Internal Server Error"),
         )


### PR DESCRIPTION
## Contexto
Um erro causado pela requisição ao endpoint `saude-mental/usuarios/novosresumo` havia travado a API pois não havia rollback da sessão no endpoint em caso de erros de execução de querys no banco, impedindo que a sessão fosse encerrada.

## Objetivo
Adicionar rollback da sessão em caso de erros de execução de query ao banco com SQL Alchemy nesse endpoint inicialmente.

## Referências
- https://docs.sqlalchemy.org/en/20/core/exceptions.html
- https://stackoverflow.com/questions/2136739/error-handling-in-sqlalchemy