### PR TITLE
[Suporte] Corrige tamanho mínimo de senha

### DIFF
--- a/app/controllers/cadastro_usuarios.py
+++ b/app/controllers/cadastro_usuarios.py
@@ -12,7 +12,7 @@ session = db.session
 
 def validar_senha(senha):
     restricoes =[]
-    if len(senha)<9: restricoes.append({"mensagem1":"Senha deve conter ao menos 8 caracteres"})
+    if len(senha)<8: restricoes.append({"mensagem1":"Senha deve conter ao menos 8 caracteres"})
     if len(re.findall('[a-z]', senha))==0: restricoes.append({"mensagem2":"Senha deve conter letras minusculas"})
     if len(re.findall('[A-Z]', senha))==0: restricoes.append({"mensagem3":"Senha deve conter letras maiusculas"})
     if len(re.findall('[0-9]', senha))==0: restricoes.append({"mensagem4":"Senha deve conter numeros"})


### PR DESCRIPTION
## Contexto
As senhas cadastradas devem ter um tamanho mínimo de 8 caracteres, mas a validação aceitava apenas senhas com no mínimo 9 caracteres.

## Objetivo
Corrigir validação para aceitar senhas a partir de 8 caracteres.