### PR TITLE
[SM] Adiciona cache nos endpoints de usuários

### DIFF
--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -43,8 +43,8 @@ def consultar_usuarios_ativos_por_estabelecimento(
     municipio_id_sus: str,
     estabelecimentos: str,
     periodos: str,
-    linhas_de_perfil: str,
-    linhas_de_idade: str
+    estabelecimento_linha_perfil: str,
+    estabelecimento_linha_idade: str
 ):
     try:
         query = session.query(
@@ -78,16 +78,16 @@ def consultar_usuarios_ativos_por_estabelecimento(
                 UsuariosPerfilEstabelecimento.periodo.in_(lista_periodos)
             )
 
-        if linhas_de_perfil is not None:
-            lista_linhas_de_perfil = separar_string("-", linhas_de_perfil)
+        if estabelecimento_linha_perfil is not None:
+            lista_linhas_de_perfil = separar_string("-", estabelecimento_linha_perfil)
             query = query.filter(
                 UsuariosPerfilEstabelecimento.estabelecimento_linha_perfil.in_(
                     lista_linhas_de_perfil
                 )
             )
 
-        if linhas_de_idade is not None:
-            lista_linhas_de_idade = separar_string("-", linhas_de_idade)
+        if estabelecimento_linha_idade is not None:
+            lista_linhas_de_idade = separar_string("-", estabelecimento_linha_idade)
             query = query.filter(
                 UsuariosPerfilEstabelecimento.estabelecimento_linha_idade.in_(
                     lista_linhas_de_idade
@@ -142,8 +142,8 @@ def consultar_usuarios_novos_resumo(
     municipio_id_sus: str,
     estabelecimentos: str,
     periodos: str,
-    linhas_de_perfil: str,
-    linhas_de_idade: str
+    estabelecimento_linha_perfil: str,
+    estabelecimento_linha_idade: str
 ):
     try:
         query = session.query(
@@ -172,16 +172,16 @@ def consultar_usuarios_novos_resumo(
                 UsuariosNovosResumo.periodo.in_(lista_periodos)
             )
 
-        if linhas_de_perfil is not None:
-            lista_linhas_de_perfil = separar_string("-", linhas_de_perfil)
+        if estabelecimento_linha_perfil is not None:
+            lista_linhas_de_perfil = separar_string("-", estabelecimento_linha_perfil)
             query = query.filter(
                 UsuariosNovosResumo.estabelecimento_linha_perfil.in_(
                     lista_linhas_de_perfil
                 )
             )
 
-        if linhas_de_idade is not None:
-            lista_linhas_de_idade = separar_string("-", linhas_de_idade)
+        if estabelecimento_linha_idade is not None:
+            lista_linhas_de_idade = separar_string("-", estabelecimento_linha_idade)
             query = query.filter(
                 UsuariosNovosResumo.estabelecimento_linha_idade.in_(lista_linhas_de_idade)
             )

--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -120,6 +120,68 @@ def obter_usuarios_novos_resumo(
         )
 
 
+def consultar_usuarios_novos_resumo(
+    municipio_id_sus: str,
+    estabelecimentos: str,
+    periodos: str,
+    linhas_de_perfil: str,
+    linhas_de_idade: str
+):
+    try:
+        query = session.query(
+            UsuariosNovosResumo.id,
+            UsuariosNovosResumo.unidade_geografica_id_sus,
+            UsuariosNovosResumo.competencia,
+            UsuariosNovosResumo.estabelecimento,
+            UsuariosNovosResumo.periodo,
+            UsuariosNovosResumo.nome_mes,
+            UsuariosNovosResumo.usuarios_novos,
+            UsuariosNovosResumo.dif_usuarios_novos_anterior,
+            UsuariosNovosResumo.estabelecimento_linha_perfil
+        ).filter(
+            UsuariosNovosResumo.unidade_geografica_id_sus == municipio_id_sus,
+        )
+
+        if estabelecimentos is not None:
+            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            query = query.filter(
+                UsuariosNovosResumo.estabelecimento.in_(lista_estabelecimentos)
+            )
+
+        if periodos is not None:
+            lista_periodos = separar_string("-", periodos)
+            query = query.filter(
+                UsuariosNovosResumo.periodo.in_(lista_periodos)
+            )
+
+        if linhas_de_perfil is not None:
+            lista_linhas_de_perfil = separar_string("-", linhas_de_perfil)
+            query = query.filter(
+                UsuariosNovosResumo.estabelecimento_linha_perfil.in_(
+                    lista_linhas_de_perfil
+                )
+            )
+
+        if linhas_de_idade is not None:
+            lista_linhas_de_idade = separar_string("-", linhas_de_idade)
+            query = query.filter(
+                UsuariosNovosResumo.estabelecimento_linha_idade.in_(lista_linhas_de_idade)
+            )
+
+        usuarios_novos = query.all()
+
+        return usuarios_novos
+    except (Exception) as error:
+        session.rollback()
+
+        print({"error": str(error)})
+
+        raise HTTPException(
+            status_code=500,
+            detail=("Internal Server Error"),
+        )
+
+
 def obter_perfil_usuarios_ativos_por_condicao(
     municipio_id_sus: str, estabelecimento: str, periodo: str
 ):

--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -39,6 +39,57 @@ def obter_usuarios_perfil_estabelecimento(
     return usuarios_perfil_estabelecimento
 
 
+def consultar_usuarios_ativos_por_estabelecimento(
+    municipio_id_sus: str,
+    estabelecimentos: str,
+    periodos: str
+):
+    try:
+        query = session.query(
+            UsuariosPerfilEstabelecimento.id,
+            UsuariosPerfilEstabelecimento.unidade_geografica_id_sus,
+            UsuariosPerfilEstabelecimento.competencia,
+            UsuariosPerfilEstabelecimento.estabelecimento,
+            UsuariosPerfilEstabelecimento.periodo,
+            UsuariosPerfilEstabelecimento.nome_mes,
+            UsuariosPerfilEstabelecimento.ativos_mes,
+            UsuariosPerfilEstabelecimento.dif_ativos_mes_anterior,
+            UsuariosPerfilEstabelecimento.ativos_3meses,
+            UsuariosPerfilEstabelecimento.dif_ativos_3meses_anterior,
+            UsuariosPerfilEstabelecimento.tornandose_inativos,
+            UsuariosPerfilEstabelecimento.dif_tornandose_inativos_anterior
+        ).filter(
+            UsuariosPerfilEstabelecimento.unidade_geografica_id_sus == municipio_id_sus,
+            UsuariosPerfilEstabelecimento.estabelecimento_linha_idade == "Todos",
+            UsuariosPerfilEstabelecimento.estabelecimento_linha_perfil == "Todos"
+        )
+
+        if estabelecimentos is not None:
+            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            query = query.filter(
+                UsuariosPerfilEstabelecimento.estabelecimento.in_(lista_estabelecimentos)
+            )
+
+        if periodos is not None:
+            lista_periodos = separar_string("-", periodos)
+            query = query.filter(
+                UsuariosPerfilEstabelecimento.periodo.in_(lista_periodos)
+            )
+
+        usuarios_ativos = query.all()
+
+        return usuarios_ativos
+    except (Exception) as error:
+        session.rollback()
+
+        print({"error": str(error)})
+
+        raise HTTPException(
+            status_code=500,
+            detail=("Internal Server Error"),
+        )
+
+
 def obter_usuarios_novos_resumo(
     municipio_id_sus: str,
 ):

--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -67,19 +67,19 @@ def consultar_usuarios_ativos_por_estabelecimento(
         )
 
         if estabelecimentos is not None:
-            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            lista_estabelecimentos = separar_string(",", estabelecimentos)
             query = query.filter(
                 UsuariosPerfilEstabelecimento.estabelecimento.in_(lista_estabelecimentos)
             )
 
         if periodos is not None:
-            lista_periodos = separar_string("-", periodos)
+            lista_periodos = separar_string(",", periodos)
             query = query.filter(
                 UsuariosPerfilEstabelecimento.periodo.in_(lista_periodos)
             )
 
         if estabelecimento_linha_perfil is not None:
-            lista_linhas_de_perfil = separar_string("-", estabelecimento_linha_perfil)
+            lista_linhas_de_perfil = separar_string(",", estabelecimento_linha_perfil)
             query = query.filter(
                 UsuariosPerfilEstabelecimento.estabelecimento_linha_perfil.in_(
                     lista_linhas_de_perfil
@@ -87,7 +87,7 @@ def consultar_usuarios_ativos_por_estabelecimento(
             )
 
         if estabelecimento_linha_idade is not None:
-            lista_linhas_de_idade = separar_string("-", estabelecimento_linha_idade)
+            lista_linhas_de_idade = separar_string(",", estabelecimento_linha_idade)
             query = query.filter(
                 UsuariosPerfilEstabelecimento.estabelecimento_linha_idade.in_(
                     lista_linhas_de_idade
@@ -161,19 +161,19 @@ def consultar_usuarios_novos_resumo(
         )
 
         if estabelecimentos is not None:
-            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            lista_estabelecimentos = separar_string(",", estabelecimentos)
             query = query.filter(
                 UsuariosNovosResumo.estabelecimento.in_(lista_estabelecimentos)
             )
 
         if periodos is not None:
-            lista_periodos = separar_string("-", periodos)
+            lista_periodos = separar_string(",", periodos)
             query = query.filter(
                 UsuariosNovosResumo.periodo.in_(lista_periodos)
             )
 
         if estabelecimento_linha_perfil is not None:
-            lista_linhas_de_perfil = separar_string("-", estabelecimento_linha_perfil)
+            lista_linhas_de_perfil = separar_string(",", estabelecimento_linha_perfil)
             query = query.filter(
                 UsuariosNovosResumo.estabelecimento_linha_perfil.in_(
                     lista_linhas_de_perfil
@@ -181,7 +181,7 @@ def consultar_usuarios_novos_resumo(
             )
 
         if estabelecimento_linha_idade is not None:
-            lista_linhas_de_idade = separar_string("-", estabelecimento_linha_idade)
+            lista_linhas_de_idade = separar_string(",", estabelecimento_linha_idade)
             query = query.filter(
                 UsuariosNovosResumo.estabelecimento_linha_idade.in_(lista_linhas_de_idade)
             )

--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -59,7 +59,9 @@ def consultar_usuarios_ativos_por_estabelecimento(
             UsuariosPerfilEstabelecimento.ativos_3meses,
             UsuariosPerfilEstabelecimento.dif_ativos_3meses_anterior,
             UsuariosPerfilEstabelecimento.tornandose_inativos,
-            UsuariosPerfilEstabelecimento.dif_tornandose_inativos_anterior
+            UsuariosPerfilEstabelecimento.dif_tornandose_inativos_anterior,
+            UsuariosPerfilEstabelecimento.sexo_predominante,
+            UsuariosPerfilEstabelecimento.usuarios_idade_media,
         ).filter(
             UsuariosPerfilEstabelecimento.unidade_geografica_id_sus == municipio_id_sus,
         )

--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -42,7 +42,9 @@ def obter_usuarios_perfil_estabelecimento(
 def consultar_usuarios_ativos_por_estabelecimento(
     municipio_id_sus: str,
     estabelecimentos: str,
-    periodos: str
+    periodos: str,
+    linhas_de_perfil: str,
+    linhas_de_idade: str
 ):
     try:
         query = session.query(
@@ -60,8 +62,6 @@ def consultar_usuarios_ativos_por_estabelecimento(
             UsuariosPerfilEstabelecimento.dif_tornandose_inativos_anterior
         ).filter(
             UsuariosPerfilEstabelecimento.unidade_geografica_id_sus == municipio_id_sus,
-            UsuariosPerfilEstabelecimento.estabelecimento_linha_idade == "Todos",
-            UsuariosPerfilEstabelecimento.estabelecimento_linha_perfil == "Todos"
         )
 
         if estabelecimentos is not None:
@@ -74,6 +74,22 @@ def consultar_usuarios_ativos_por_estabelecimento(
             lista_periodos = separar_string("-", periodos)
             query = query.filter(
                 UsuariosPerfilEstabelecimento.periodo.in_(lista_periodos)
+            )
+
+        if linhas_de_perfil is not None:
+            lista_linhas_de_perfil = separar_string("-", linhas_de_perfil)
+            query = query.filter(
+                UsuariosPerfilEstabelecimento.estabelecimento_linha_perfil.in_(
+                    lista_linhas_de_perfil
+                )
+            )
+
+        if linhas_de_idade is not None:
+            lista_linhas_de_idade = separar_string("-", linhas_de_idade)
+            query = query.filter(
+                UsuariosPerfilEstabelecimento.estabelecimento_linha_idade.in_(
+                    lista_linhas_de_idade
+                )
             )
 
         usuarios_ativos = query.all()

--- a/app/models/saude_mental/usuariosnovos/caps_usuarios_novos_resumo.py
+++ b/app/models/saude_mental/usuariosnovos/caps_usuarios_novos_resumo.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Date, Float, Integer, Text
-from sqlalchemy.dialects.postgresql import UUID, VARCHAR
+from sqlalchemy.dialects.postgresql import UUID, VARCHAR, TIMESTAMP
 from app.models.saude_mental.schema import SCHEMA_SAUDE_MENTAL
 
 from app.models import db
@@ -23,4 +23,5 @@ class UsuariosNovosResumo(Base):
     usuarios_novos = Column(Integer)
     usuarios_novos_anterior = Column(Integer)
     dif_usuarios_novos_anterior = Column(Integer)
+    atualizacao_data = Column(TIMESTAMP(timezone=True))
     __table_args__ = {"schema": SCHEMA_SAUDE_MENTAL}

--- a/app/routers/saude_mental/usuarios.py
+++ b/app/routers/saude_mental/usuarios.py
@@ -35,8 +35,8 @@ async def obter_usuarios_ativos_por_estabelecimento(
     municipio_id_sus: str,
     estabelecimentos: Union[str, None] = None,
     periodos: Union[str, None] = None,
-    linhas_de_perfil: Union[str, None] = None,
-    linhas_de_idade: Union[str, None] = None,
+    estabelecimento_linha_perfil: Union[str, None] = None,
+    estabelecimento_linha_idade: Union[str, None] = None,
 ):
     response.headers["Cache-Control"] = f"private, max-age={QUANTIDADE_SEGUNDOS_24_HORAS}"
 
@@ -44,8 +44,8 @@ async def obter_usuarios_ativos_por_estabelecimento(
         municipio_id_sus=municipio_id_sus,
         estabelecimentos=estabelecimentos,
         periodos=periodos,
-        linhas_de_perfil=linhas_de_perfil,
-        linhas_de_idade=linhas_de_idade
+        estabelecimento_linha_perfil=estabelecimento_linha_perfil,
+        estabelecimento_linha_idade=estabelecimento_linha_idade
     )
 
 
@@ -62,8 +62,8 @@ async def obter_resumo_usuarios_novos(
     municipio_id_sus: str,
     estabelecimentos: Union[str, None] = None,
     periodos: Union[str, None] = None,
-    linhas_de_perfil: Union[str, None] = None,
-    linhas_de_idade: Union[str, None] = None,
+    estabelecimento_linha_perfil: Union[str, None] = None,
+    estabelecimento_linha_idade: Union[str, None] = None,
 ):
     response.headers["Cache-Control"] = f"private, max-age={QUANTIDADE_SEGUNDOS_24_HORAS}"
 
@@ -71,8 +71,8 @@ async def obter_resumo_usuarios_novos(
         municipio_id_sus=municipio_id_sus,
         estabelecimentos=estabelecimentos,
         periodos=periodos,
-        linhas_de_perfil=linhas_de_perfil,
-        linhas_de_idade=linhas_de_idade,
+        estabelecimento_linha_perfil=estabelecimento_linha_perfil,
+        estabelecimento_linha_idade=estabelecimento_linha_idade,
     )
 
 

--- a/app/routers/saude_mental/usuarios.py
+++ b/app/routers/saude_mental/usuarios.py
@@ -35,6 +35,8 @@ async def obter_usuarios_ativos_por_estabelecimento(
     municipio_id_sus: str,
     estabelecimentos: Union[str, None] = None,
     periodos: Union[str, None] = None,
+    linhas_de_perfil: Union[str, None] = None,
+    linhas_de_idade: Union[str, None] = None,
 ):
     response.headers["Cache-Control"] = f"private, max-age={QUANTIDADE_SEGUNDOS_24_HORAS}"
 
@@ -42,6 +44,8 @@ async def obter_usuarios_ativos_por_estabelecimento(
         municipio_id_sus=municipio_id_sus,
         estabelecimentos=estabelecimentos,
         periodos=periodos,
+        linhas_de_perfil=linhas_de_perfil,
+        linhas_de_idade=linhas_de_idade
     )
 
 

--- a/app/routers/saude_mental/usuarios.py
+++ b/app/routers/saude_mental/usuarios.py
@@ -13,7 +13,8 @@ from app.controllers.saude_mental.usuarios import (
     obter_perfil_usuarios_novos_por_raca,
     obter_usuarios_novos_resumo,
     obter_usuarios_perfil_estabelecimento,
-    consultar_usuarios_ativos_por_estabelecimento
+    consultar_usuarios_ativos_por_estabelecimento,
+    consultar_usuarios_novos_resumo
 )
 
 QUANTIDADE_SEGUNDOS_24_HORAS = 60 * 60 * 24
@@ -49,6 +50,26 @@ async def obter_novos_usuarios_resumo(
     municipio_id_sus: str,
 ):
     return obter_usuarios_novos_resumo(municipio_id_sus=municipio_id_sus)
+
+
+@router.get("/saude-mental/usuarios/novos/resumo")
+async def obter_resumo_usuarios_novos(
+    response: Response,
+    municipio_id_sus: str,
+    estabelecimentos: Union[str, None] = None,
+    periodos: Union[str, None] = None,
+    linhas_de_perfil: Union[str, None] = None,
+    linhas_de_idade: Union[str, None] = None,
+):
+    response.headers["Cache-Control"] = f"private, max-age={QUANTIDADE_SEGUNDOS_24_HORAS}"
+
+    return consultar_usuarios_novos_resumo(
+        municipio_id_sus=municipio_id_sus,
+        estabelecimentos=estabelecimentos,
+        periodos=periodos,
+        linhas_de_perfil=linhas_de_perfil,
+        linhas_de_idade=linhas_de_idade,
+    )
 
 
 @router.get("/saude-mental/usuarios/perfil/condicao")

--- a/app/routers/saude_mental/usuarios.py
+++ b/app/routers/saude_mental/usuarios.py
@@ -1,4 +1,6 @@
 from fastapi import APIRouter
+from fastapi.responses import Response
+from typing import Union
 
 from app.controllers.saude_mental.usuarios import (
     obter_perfil_usuarios_ativos_por_cid,
@@ -11,7 +13,10 @@ from app.controllers.saude_mental.usuarios import (
     obter_perfil_usuarios_novos_por_raca,
     obter_usuarios_novos_resumo,
     obter_usuarios_perfil_estabelecimento,
+    consultar_usuarios_ativos_por_estabelecimento
 )
+
+QUANTIDADE_SEGUNDOS_24_HORAS = 60 * 60 * 24
 
 router = APIRouter()
 
@@ -21,6 +26,22 @@ async def obter_perfil_usuarios_estabelecimento(
     municipio_id_sus: str,
 ):
     return obter_usuarios_perfil_estabelecimento(municipio_id_sus=municipio_id_sus)
+
+
+@router.get("/saude-mental/usuarios/perfil/por-estabelecimento")
+async def obter_usuarios_ativos_por_estabelecimento(
+    response: Response,
+    municipio_id_sus: str,
+    estabelecimentos: Union[str, None] = None,
+    periodos: Union[str, None] = None,
+):
+    response.headers["Cache-Control"] = f"private, max-age={QUANTIDADE_SEGUNDOS_24_HORAS}"
+
+    return consultar_usuarios_ativos_por_estabelecimento(
+        municipio_id_sus=municipio_id_sus,
+        estabelecimentos=estabelecimentos,
+        periodos=periodos,
+    )
 
 
 @router.get("/saude-mental/usuarios/novosresumo")


### PR DESCRIPTION
### Objetivo
- Criar novos endpoints de resumo de novos usuários e de usuários ativos por estabelecimento, adicionando cache e os seguintes filtros opcionais:
  - estabelecimentos
  - periodos
  - estabelecimento_linha_perfil 
  - estabelecimento_linha_perfil
- Adicionar colunas ausentes no model de `UsuariosNovosResumo`
- Usar o novo separador de valores dos parâmetros dos endpoints, como descrito em https://github.com/ImpulsoGov/api-webapp/issues/140