### PR TITLE
[SM] Remove erro 404 para busca de múltiplos usuários

### DIFF
--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -81,18 +81,8 @@ def obter_perfil_usuarios_ativos_por_condicao(
             .all()
         )
 
-        if len(usuarios_ativos_por_condicao) == 0:
-            raise HTTPException(
-                status_code=404,
-                detail=("Dados de condição de usuários ativos não encontrados."),
-            )
-
         return usuarios_ativos_por_condicao
-    except HTTPException as error:
-        session.rollback()
-
-        raise error
-    except (exc.SQLAlchemyError, Exception) as error:
+    except (Exception) as error:
         session.rollback()
 
         print({"error": str(error)})
@@ -115,18 +105,8 @@ def obter_perfil_usuarios_ativos_por_genero_e_idade(
             .all()
         )
 
-        if len(usuarios_ativos_por_genero_e_idade) == 0:
-            raise HTTPException(
-                status_code=404,
-                detail=("Dados de gênero/idade de usuários ativos não encontrados."),
-            )
-
         return usuarios_ativos_por_genero_e_idade
-    except HTTPException as error:
-        session.rollback()
-
-        raise error
-    except (exc.SQLAlchemyError, Exception) as error:
+    except (Exception) as error:
         session.rollback()
 
         print({"error": str(error)})
@@ -149,18 +129,8 @@ def obter_perfil_usuarios_ativos_por_raca(
             .all()
         )
 
-        if len(usuarios_ativos_por_raca) == 0:
-            raise HTTPException(
-                status_code=404,
-                detail=("Dados de raça/cor de usuários ativos não encontrados."),
-            )
-
         return usuarios_ativos_por_raca
-    except HTTPException as error:
-        session.rollback()
-
-        raise error
-    except (exc.SQLAlchemyError, Exception) as error:
+    except (Exception) as error:
         session.rollback()
 
         print({"error": str(error)})
@@ -183,18 +153,8 @@ def obter_perfil_usuarios_ativos_por_cid(
             .all()
         )
 
-        if len(usuarios_ativos_por_cid) == 0:
-            raise HTTPException(
-                status_code=404,
-                detail=("Dados de cid de usuários ativos não encontrados."),
-            )
-
         return usuarios_ativos_por_cid
-    except HTTPException as error:
-        session.rollback()
-
-        raise error
-    except (exc.SQLAlchemyError, Exception) as error:
+    except (Exception) as error:
         session.rollback()
 
         print({"error": str(error)})


### PR DESCRIPTION
### Objetivos
- Remover erro 404 para buscas de múltiplos dados de um município quando ele não não possui dados banco, retornando apenas uma lista vazia 