### PR TITLE
[SM] Executa rollback em caso de erro nos controllers de Outros RAPS

### DIFF
--- a/app/controllers/saude_mental/ambulatorio.py
+++ b/app/controllers/saude_mental/ambulatorio.py
@@ -10,6 +10,7 @@ from app.utils.separar_string import separar_string
 
 session = db.session
 
+
 def consultar_dados_ambulatorio_atendimento_resumo(
     municipio_id_sus: str,
     estabelecimentos: str,
@@ -44,37 +45,46 @@ def consultar_dados_ambulatorio_atendimento_resumo(
 def obter_ambulatorio_atendimento_resumo_ultimo_mes(
     municipio_id_sus: str,
 ):
-    ambulatorio_atendimento_resumo_ultimo_mes = (
-        session.query(AmbulatorioAtendimentoResumoUltimoMes)
-        .filter_by(unidade_geografica_id_sus=municipio_id_sus)
-        .all()
-    )
-
-    if len(ambulatorio_atendimento_resumo_ultimo_mes) == 0:
-        raise HTTPException(
-            status_code=404,
-            detail=("Dados não encontrados",),
+    try:
+        ambulatorio_atendimento_resumo_ultimo_mes = (
+            session.query(AmbulatorioAtendimentoResumoUltimoMes)
+            .filter_by(unidade_geografica_id_sus=municipio_id_sus)
+            .all()
         )
 
-    return ambulatorio_atendimento_resumo_ultimo_mes
+        return ambulatorio_atendimento_resumo_ultimo_mes
+    except (Exception) as error:
+        session.rollback()
+
+        print({"error": str(error)})
+
+        raise HTTPException(
+            status_code=500,
+            detail=("Internal Server Error"),
+        )
 
 
 def obter_ambulatorio_procedimento_por_profissional(
     municipio_id_sus: str,
 ):
-    ambulatorio_procedimento_por_profissional = (
-        session.query(AmbulatorioProcedimentosPorProfissional)
-        .filter_by(unidade_geografica_id_sus=municipio_id_sus)
-        .all()
-    )
-
-    if len(ambulatorio_procedimento_por_profissional) == 0:
-        raise HTTPException(
-            status_code=404,
-            detail=("Dados não encontrados",),
+    try:
+        ambulatorio_procedimento_por_profissional = (
+            session.query(AmbulatorioProcedimentosPorProfissional)
+            .filter_by(unidade_geografica_id_sus=municipio_id_sus)
+            .all()
         )
 
-    return ambulatorio_procedimento_por_profissional
+        return ambulatorio_procedimento_por_profissional
+    except (Exception) as error:
+        session.rollback()
+
+        print({"error": str(error)})
+
+        raise HTTPException(
+            status_code=500,
+            detail=("Internal Server Error"),
+        )
+
 
 def consultar_ambulatorio_usuario_perfil(
     municipio_id_sus: str,
@@ -93,7 +103,7 @@ def consultar_ambulatorio_usuario_perfil(
                 )
         if periodos is not None:
                 lista_periodos = separar_string("-", periodos)
-                query = query.filter(AmbulatorioUsuariosPerfil.periodo.in_(lista_periodos))        
+                query = query.filter(AmbulatorioUsuariosPerfil.periodo.in_(lista_periodos))
 
         ambulatorio_usuario_perfil = query.all()
         return ambulatorio_usuario_perfil

--- a/app/controllers/saude_mental/consultorionarua.py
+++ b/app/controllers/saude_mental/consultorionarua.py
@@ -10,34 +10,42 @@ session = db.session
 
 
 def dados_consultorionarua_atendimentos(municipio_id_sus: str):
-    dados_consultorionarua_atendimentos = (
-        session.query(ConsultorionaruaAtendimentos)
-        .filter_by(unidade_geografica_id_sus=municipio_id_sus)
-        .all()
-    )
-
-    if len(dados_consultorionarua_atendimentos) == 0:
-        raise HTTPException(
-            status_code=404,
-            detail="Dados de Consultorio na Rua não encontrados",
+    try:
+        dados_consultorionarua_atendimentos = (
+            session.query(ConsultorionaruaAtendimentos)
+            .filter_by(unidade_geografica_id_sus=municipio_id_sus)
+            .all()
         )
 
-    return dados_consultorionarua_atendimentos
+        return dados_consultorionarua_atendimentos
+    except (Exception) as error:
+        session.rollback()
+
+        print({"error": str(error)})
+
+        raise HTTPException(
+            status_code=500,
+            detail=("Internal Server Error"),
+        )
 
 
 def dados_consultorionarua_atendimentos_12meses(
     municipio_id_sus: str,
 ):
-    dados_consultorionarua_atendimentos_12meses = (
-        session.query(ConsultorionaruaAtendimentos12meses)
-        .filter_by(unidade_geografica_id_sus=municipio_id_sus)
-        .all()
-    )
-
-    if len(dados_consultorionarua_atendimentos_12meses) == 0:
-        raise HTTPException(
-            status_code=404,
-            detail=("Dados de Consultorio na Rua dos 12 meses não encontrados",),
+    try:
+        dados_consultorionarua_atendimentos_12meses = (
+            session.query(ConsultorionaruaAtendimentos12meses)
+            .filter_by(unidade_geografica_id_sus=municipio_id_sus)
+            .all()
         )
 
-    return dados_consultorionarua_atendimentos_12meses
+        return dados_consultorionarua_atendimentos_12meses
+    except (Exception) as error:
+        session.rollback()
+
+        print({"error": str(error)})
+
+        raise HTTPException(
+            status_code=500,
+            detail=("Internal Server Error"),
+        )

--- a/app/controllers/saude_mental/reducaodedanos.py
+++ b/app/controllers/saude_mental/reducaodedanos.py
@@ -80,16 +80,20 @@ def consultar_nomes_de_ocupacoes_reducao_de_danos(municipio_id_sus: str):
 def dados_reducaodedanos_12meses(
     municipio_id_sus: str,
 ):
-    dados_reducaodedanos_12meses = (
-        session.query(ReducaoDanos12meses)
-        .filter_by(unidade_geografica_id_sus=municipio_id_sus)
-        .all()
-    )
-
-    if len(dados_reducaodedanos_12meses) == 0:
-        raise HTTPException(
-            status_code=404,
-            detail=("Dados de Redução de danos dos 12 meses não encontrados",),
+    try:
+        dados_reducaodedanos_12meses = (
+            session.query(ReducaoDanos12meses)
+            .filter_by(unidade_geografica_id_sus=municipio_id_sus)
+            .all()
         )
 
-    return dados_reducaodedanos_12meses
+        return dados_reducaodedanos_12meses
+    except (Exception) as error:
+        session.rollback()
+
+        print({"error": str(error)})
+
+        raise HTTPException(
+            status_code=500,
+            detail=("Internal Server Error"),
+        )


### PR DESCRIPTION
### Contexto
No dia 24/11/2023, alguns endpoints de Outros RAPS apresentaram o seguinte erro:
```
sqlalchemy.exc.PendingRollbackError: Can't reconnect until invalid transaction is rolled back. (Background on this error at: https://sqlalche.me/e/14/8s2b)
```

O fato de uma transação inválida não ter seu rollback feito faz com que os próximos usos da sessão fiquem travados até que aquela transação faça rollback.

### Alterações feitas

Como a classe `PendingRollbackError` é uma subclasse de `SQLAlchemyError`, que por sua vez é uma subclasse da `Exception` do python, a solução tomada foi implementar o seguinte bloco `try/except` nos controllers de Outros RAPS para executar o rollback da sessão em caso de erros inesperados:
```
    try:
        #execução de consulta no banco
        return  session.query(...)
    except (Exception) as error:
        session.rollback()

        print({"error": str(error)})

        raise HTTPException(
            status_code=500,
            detail=("Internal Server Error"),
        )
```

Além disso, foi também retirado o lançamento de erros 404 Not Found desses controllers pois fazem consulta de uma lista de dados de um município nas tabelas do banco, podendo retornar uma lista vazia caso os dados do município buscado não existam na tabela.