### PR TITLE
[SM] Correção de caractere separador de string 

### DIFF
--- a/app/controllers/saude_mental/ambulatorio.py
+++ b/app/controllers/saude_mental/ambulatorio.py
@@ -22,13 +22,13 @@ def consultar_dados_ambulatorio_atendimento_resumo(
         )
 
         if estabelecimentos is not None:
-            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            lista_estabelecimentos = separar_string(",", estabelecimentos)
             query = query.filter(
                 AmbulatorioAtendimentoResumo.estabelecimento.in_(lista_estabelecimentos)
             )
 
         if periodos is not None:
-            lista_periodos = separar_string("-", periodos)
+            lista_periodos = separar_string(",", periodos)
             query = query.filter(AmbulatorioAtendimentoResumo.periodo.in_(lista_periodos))    
 
         ambulatorio_atendimento_resumo = query.all()
@@ -97,13 +97,13 @@ def consultar_ambulatorio_usuario_perfil(
         ).filter(AmbulatorioUsuariosPerfil.unidade_geografica_id_sus == municipio_id_sus)
 
         if estabelecimentos is not None:
-                lista_estabelecimentos = separar_string("-", estabelecimentos)
-                query = query.filter(
-                    AmbulatorioUsuariosPerfil.estabelecimento.in_(lista_estabelecimentos)
-                )
+            lista_estabelecimentos = separar_string(",", estabelecimentos)
+            query = query.filter(
+                AmbulatorioUsuariosPerfil.estabelecimento.in_(lista_estabelecimentos)
+            )
         if periodos is not None:
-                lista_periodos = separar_string("-", periodos)
-                query = query.filter(AmbulatorioUsuariosPerfil.periodo.in_(lista_periodos))
+            lista_periodos = separar_string(",", periodos)
+            query = query.filter(AmbulatorioUsuariosPerfil.periodo.in_(lista_periodos))
 
         ambulatorio_usuario_perfil = query.all()
         return ambulatorio_usuario_perfil

--- a/app/controllers/saude_mental/procedimentos.py
+++ b/app/controllers/saude_mental/procedimentos.py
@@ -70,13 +70,13 @@ def consultar_procedimentos_por_hora(
         ).filter(ProcedimentosPorHora.unidade_geografica_id_sus == municipio_id_sus)
 
         if estabelecimentos is not None:
-            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            lista_estabelecimentos = separar_string(",", estabelecimentos)
             query = query.filter(
                 ProcedimentosPorHora.estabelecimento.in_(lista_estabelecimentos)
             )
 
         if periodos is not None:
-            lista_periodos = separar_string("-", periodos)
+            lista_periodos = separar_string(",", periodos)
             query = query.filter(ProcedimentosPorHora.periodo.in_(lista_periodos))
 
         if ocupacao is not None:
@@ -118,21 +118,21 @@ def consultar_procedimentos_por_tipo(
         )
 
         if estabelecimentos is not None:
-            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            lista_estabelecimentos = separar_string(",", estabelecimentos)
 
             query = query.filter(
                 ProcedimentosPorTipo.estabelecimento.in_(lista_estabelecimentos)
             )
 
         if periodos is not None:
-            lista_periodos = separar_string("-", periodos)
+            lista_periodos = separar_string(",", periodos)
 
             query = query.filter(
                 ProcedimentosPorTipo.periodo.in_(lista_periodos)
             )
 
         if procedimentos is not None:
-            lista_procedimentos = separar_string("-", procedimentos)
+            lista_procedimentos = separar_string(",", procedimentos)
 
             query = query.filter(
                 ProcedimentosPorTipo.procedimento.in_(lista_procedimentos)
@@ -194,7 +194,7 @@ def consultar_procedimentos_por_usuario_tempo_servico(
         )
 
         if estabelecimentos is not None:
-            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            lista_estabelecimentos = separar_string(",", estabelecimentos)
 
             query = query.filter(
                 ProcedimentoPorUsuarioTempoServiço
@@ -202,7 +202,7 @@ def consultar_procedimentos_por_usuario_tempo_servico(
             )
 
         if periodos is not None:
-            lista_periodos = separar_string("-", periodos)
+            lista_periodos = separar_string(",", periodos)
 
             query = query.filter(
                 ProcedimentoPorUsuarioTempoServiço.periodo.in_(lista_periodos)

--- a/app/controllers/saude_mental/reducaodedanos.py
+++ b/app/controllers/saude_mental/reducaodedanos.py
@@ -29,17 +29,17 @@ def consultar_reducao_de_danos(
         ).filter(ReducaoDanos.unidade_geografica_id_sus == municipio_id_sus)
 
         if estabelecimentos is not None:
-            lista_estabelecimentos = separar_string("-", estabelecimentos)
+            lista_estabelecimentos = separar_string(",", estabelecimentos)
             query = query.filter(
                 ReducaoDanos.estabelecimento.in_(lista_estabelecimentos)
             )
 
         if periodos is not None:
-            lista_periodos = separar_string("-", periodos)
+            lista_periodos = separar_string(",", periodos)
             query = query.filter(ReducaoDanos.periodo.in_(lista_periodos))
 
         if ocupacoes is not None:
-            lista_ocupacoes = separar_string("-", ocupacoes)
+            lista_ocupacoes = separar_string(",", ocupacoes)
             query = query.filter(ReducaoDanos.profissional_vinculo_ocupacao.in_(lista_ocupacoes))
 
         procedimentos_por_hora = query.all()


### PR DESCRIPTION
### Descrição
No dia 23/11/23 recebemos um ticket de suporte informando que os dados de **Produção** do caps Beija-flor do município de Vila Velha/ES não estavam disponíveis no painel.
Após investigação, descobrimos que usavámos o caractere "-" como separador de string em uma das funções auxiliares dos controllers de procedimentos para filtrar dados por múltiplos valores(ex filtrar por estabelecimento A, B e C).
### Objetivos
- Documentar a ocorrência desse problema.
- Corrigir o problema para os novos endpoints de procedimentos, de ambulatório e redução de danos. Eles são os únicos que recebem múltiplos valores de estabelecimento como parâmetro. 
### Solução
Concluímos que uma solução poderia ser trocar o caractere utilizado como separador de "-" para ",", haja vista que não há municípios com "," no nome. Além de não se chocar com outras convenções utilizadas na codebase.
### Endpoints corrigidos
- `/saude-mental/reducao-de-danos`
- `/saude-mental/ambulatorio/atendimento_resumo`
- `/saude-mental/ambulatorio/usuario_perfil`
- `/saude-mental/procedimentos-por-tipo/procedimentos`
- `/saude-mental//procedimentos-por-hora`