### PR TITLE
[SM] Remove endpoints inutilizados de usuários

### DIFF
--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -21,24 +21,6 @@ from app.utils.separar_string import separar_string
 session = db.session
 
 
-def obter_usuarios_perfil_estabelecimento(
-    municipio_id_sus: str,
-):
-    usuarios_perfil_estabelecimento = (
-        session.query(UsuariosPerfilEstabelecimento)
-        .filter_by(unidade_geografica_id_sus=municipio_id_sus)
-        .all()
-    )
-
-    if len(usuarios_perfil_estabelecimento) == 0:
-        raise HTTPException(
-            status_code=404,
-            detail=("Dado perfil estabelecimento não encontrado."),
-        )
-
-    return usuarios_perfil_estabelecimento
-
-
 def consultar_usuarios_ativos_por_estabelecimento(
     municipio_id_sus: str,
     estabelecimentos: str,

--- a/app/controllers/saude_mental/usuarios.py
+++ b/app/controllers/saude_mental/usuarios.py
@@ -90,36 +90,6 @@ def consultar_usuarios_ativos_por_estabelecimento(
         )
 
 
-def obter_usuarios_novos_resumo(
-    municipio_id_sus: str,
-):
-    try:
-        usuarios_novos_resumo = (
-            session.query(UsuariosNovosResumo)
-            .filter_by(unidade_geografica_id_sus=municipio_id_sus)
-            .all()
-        )
-
-        if len(usuarios_novos_resumo) == 0:
-            raise HTTPException(
-                status_code=404,
-                detail=("Dados usuarios resumo novos não encontrados."),
-            )
-
-        return usuarios_novos_resumo
-    except exc.SQLAlchemyError as e:
-        session.rollback()
-
-        error = str(e)
-
-        print({"error": error})
-
-        raise HTTPException(
-            status_code=500,
-            detail=("Internal Server Error"),
-        )
-
-
 def consultar_usuarios_novos_resumo(
     municipio_id_sus: str,
     estabelecimentos: str,

--- a/app/routers/saude_mental/usuarios.py
+++ b/app/routers/saude_mental/usuarios.py
@@ -11,8 +11,6 @@ from app.controllers.saude_mental.usuarios import (
     obter_perfil_usuarios_novos_por_condicao,
     obter_perfil_usuarios_novos_por_genero_e_idade,
     obter_perfil_usuarios_novos_por_raca,
-    obter_usuarios_novos_resumo,
-    obter_usuarios_perfil_estabelecimento,
     consultar_usuarios_ativos_por_estabelecimento,
     consultar_usuarios_novos_resumo
 )

--- a/app/routers/saude_mental/usuarios.py
+++ b/app/routers/saude_mental/usuarios.py
@@ -22,13 +22,6 @@ QUANTIDADE_SEGUNDOS_24_HORAS = 60 * 60 * 24
 router = APIRouter()
 
 
-@router.get("/saude-mental/usuarios/perfilestabelecimento")
-async def obter_perfil_usuarios_estabelecimento(
-    municipio_id_sus: str,
-):
-    return obter_usuarios_perfil_estabelecimento(municipio_id_sus=municipio_id_sus)
-
-
 @router.get("/saude-mental/usuarios/perfil/por-estabelecimento")
 async def obter_usuarios_ativos_por_estabelecimento(
     response: Response,

--- a/app/routers/saude_mental/usuarios.py
+++ b/app/routers/saude_mental/usuarios.py
@@ -42,13 +42,6 @@ async def obter_usuarios_ativos_por_estabelecimento(
     )
 
 
-@router.get("/saude-mental/usuarios/novosresumo")
-async def obter_novos_usuarios_resumo(
-    municipio_id_sus: str,
-):
-    return obter_usuarios_novos_resumo(municipio_id_sus=municipio_id_sus)
-
-
 @router.get("/saude-mental/usuarios/novos/resumo")
 async def obter_resumo_usuarios_novos(
     response: Response,


### PR DESCRIPTION
### Descrição
Nos últimos meses, o time de engenharia tem feito a adição do header de HTTP Cache-control e filtros opcionais nos endpoints de saúde mental da API para melhorar seu desempenho.
Nesse processo, eram criados novos endpoints com o header e os filtros para substituir os antigos sem que essa troca afetasse a plataforma de saúde mental, o que fez com que alguns endpoints da API ficassem inutilizados.

### Objetivos
- Remover os endpoints de saúde mental que ficaram inutilizados a partir do PR #134 

### Como validar
- Faça deploy dessa branch na api de staging de saúde mental
- Adiciona a URL da api de staging de saúde mental na versão local da plataforma de indicadores e navegue pelas páginas de Perfil de usuário e Novos usuários, observando se erros acontecem