### PR TITLE
Adiciona Sentry

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,3 +47,8 @@ class Welcome(BaseModel):
 @app.get("/", response_model=Welcome)
 async def main():
     return {"mensagem": "Bem Vindo"}
+
+
+@app.get("/sentry-debug")
+async def trigger_error():
+    division_by_zero = 1 / 0

--- a/app/main.py
+++ b/app/main.py
@@ -2,12 +2,24 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from pydantic import BaseModel
+import sentry_sdk
 from app.routers import (
     impulso_previne_publico,
     impulso_previne_nominal,
     saude_mental,
     territorios,
     usuarios,
+)
+
+sentry_sdk.init(
+    dsn="https://2bf90390fba62a2238c1b372df068142@o4506520445517824.ingest.sentry.io/4506537208250368",
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,
 )
 
 app = FastAPI()

--- a/app/main.py
+++ b/app/main.py
@@ -47,8 +47,3 @@ class Welcome(BaseModel):
 @app.get("/", response_model=Welcome)
 async def main():
     return {"mensagem": "Bem Vindo"}
-
-
-@app.get("/sentry-debug")
-async def trigger_error():
-    division_by_zero = 1 / 0

--- a/app/main.py
+++ b/app/main.py
@@ -46,8 +46,3 @@ class Welcome(BaseModel):
 @app.get("/", response_model=Welcome)
 async def main():
     return {"mensagem": "Bem Vindo"}
-
-
-@app.get("/sentry-debug")
-async def trigger_error():
-    division_by_zero = 1 / 0

--- a/app/main.py
+++ b/app/main.py
@@ -13,12 +13,7 @@ from app.routers import (
 
 sentry_sdk.init(
     dsn="https://2bf90390fba62a2238c1b372df068142@o4506520445517824.ingest.sentry.io/4506537208250368",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
     traces_sample_rate=1.0,
-    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
     profiles_sample_rate=1.0,
 )
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -12,7 +13,7 @@ from app.routers import (
 )
 
 sentry_sdk.init(
-    dsn="https://2bf90390fba62a2238c1b372df068142@o4506520445517824.ingest.sentry.io/4506537208250368",
+    dsn=os.getenv("SENTRY_DSN"),
     traces_sample_rate=1.0,
     profiles_sample_rate=1.0,
 )

--- a/app/main.py
+++ b/app/main.py
@@ -46,3 +46,8 @@ class Welcome(BaseModel):
 @app.get("/", response_model=Welcome)
 async def main():
     return {"mensagem": "Bem Vindo"}
+
+
+@app.get("/sentry-debug")
+async def trigger_error():
+    division_by_zero = 1 / 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ python-multipart==0.0.6
 pytz==2023.3
 requests==2.31.0
 rsa==4.9
+sentry-sdk==1.39.1
 six==1.16.0
 sniffio==1.3.0
 SQLAlchemy==1.4.31


### PR DESCRIPTION
### Objetivos
- Instalar e configurar Sentry na API para capturar e manter um histórico detalhado dos erros que acontecem na aplicação

### Checklist
- [x] Adicionar SENTRY_DSN para as APIs de produção:
  - `api-usuarios`
  - `api-ip-publico`
  - `api-ip-nominal`
- [x] Remover SENTRY_DSN da api de revisão `api-ip-nomin-feat-sentr-2tsk0t`
- [x] Remover rota de exemplo do PR