### PR TITLE
Validação de perfis conflitantes

### DIFF
--- a/app/controllers/usuarios/gerenciamento_usuarios.py
+++ b/app/controllers/usuarios/gerenciamento_usuarios.py
@@ -243,7 +243,7 @@ def validar_perfis_conflitantes(novo_perfil: int, perfis_cadastrados: set) -> No
         raise HTTPException(
             status_code=400,
             detail=f"""
-            O perfil {novo_perfil} não foi adicionado pois os perfis
+            O perfil {novo_perfil} não pode ser adicionado pois os perfis
             conflitantes {conflitos} já estão cadastrados
             """
         )

--- a/app/controllers/usuarios/gerenciamento_usuarios.py
+++ b/app/controllers/usuarios/gerenciamento_usuarios.py
@@ -9,7 +9,7 @@ import re
 import uuid
 from datetime import datetime
 from typing import List, NoReturn, Union
-from collections.abc import Iterable
+from typing import Iterable
 
 from email_validator import EmailNotValidError, validate_email
 from fastapi import HTTPException

--- a/app/controllers/usuarios/gerenciamento_usuarios.py
+++ b/app/controllers/usuarios/gerenciamento_usuarios.py
@@ -211,6 +211,34 @@ def dados_usuarios(id_cod, id, username, acesso):
 
 
 def add_perfil(id_cod, id, perfil, username, acesso):
+    """Adiciona novo perfil a um usuário já cadastrado
+
+    Parameters
+    ----------
+    id_cod : int
+        número que define como o usuário que receberá um novo perfil será encontrado.
+        Número 1 para encontrar o usuário pelo email ou
+        número 2 para encontrar o usuário pelo cpf
+    id : str
+        identificador único (email ou cpf) do usuário que receberá um novo perfil.
+        Se id_cod for igual a 1, o id deve receber o email do usuário.
+        Se id_cod for igual a 2, o id deve receber o cpf do usuário
+    perfil : int
+        número do perfil que será adicionado ao usuário
+    username : list[int]
+        lista de perfis já cadastrados do usuário que está usando o endpoint
+        para adicionar um perfil a outro usuário. Este dado é necessário para
+        saber se quem está usando o endpoint tem permissão para modificar a
+        lista de perfis de outra pessoa.
+    acesso : int
+        perfil que tem permissão para gerir dados de outros usuários
+
+    Returns
+    -------
+    dict ou Exception
+        Retorna um dict com mensagem de sucesso/validação/falha
+        ou uma Exception caso algum erro inesperado ocorra
+    """
     # controle de acesso
     controle = auth.controle_perfil(username, acesso)
     if controle != True:

--- a/app/controllers/usuarios/gerenciamento_usuarios.py
+++ b/app/controllers/usuarios/gerenciamento_usuarios.py
@@ -227,12 +227,20 @@ def validar_perfis_conflitantes(
 
     Raises
     ------
+    TypeError
+        Lança um TypeError quando qualquer argumento não é passado
     HTTPException
         Lança uma HTTPException com status 400 (Bad Request),
         indicando que o usuário já possui cadastrados perfis
         conflitantes com o novo perfil a ser adicionado,
         interrompendo o processo de atualização de perfil
     """
+    if novo_perfil is None:
+        raise TypeError("O parâmetro novo_perfil é obrigatório")
+
+    if perfis_cadastrados is None:
+        raise TypeError("O parâmetro perfis_cadastrados é obrigatório")
+
     relacao_de_conflitos = {8: set([9]), 9: set([8])}
     perfis_conflitantes = relacao_de_conflitos.get(novo_perfil, set())
     conflitos = set(perfis_cadastrados).intersection(perfis_conflitantes)
@@ -247,7 +255,7 @@ def validar_perfis_conflitantes(
         )
 
 
-# TODO MELHORIA: checar se o perfil recebido é um dos perfis válidos
+# TODO checar se o perfil recebido é um dos perfis válidos
 def add_perfil(id_cod, id, perfil, username, acesso):
     """Adiciona novo perfil a um usuário já cadastrado
 

--- a/app/controllers/usuarios/gerenciamento_usuarios.py
+++ b/app/controllers/usuarios/gerenciamento_usuarios.py
@@ -249,28 +249,29 @@ def validar_perfis_conflitantes(novo_perfil: int, perfis_cadastrados: set) -> No
         )
 
 
+# TODO MELHORIA: checar se o perfil recebido é um dos perfis válidos
 def add_perfil(id_cod, id, perfil, username, acesso):
     """Adiciona novo perfil a um usuário já cadastrado
 
     Parameters
     ----------
     id_cod : int
-        número que define como o usuário que receberá um novo perfil será encontrado.
+        Número que define como o usuário que receberá um novo perfil será encontrado.
         Número 1 para encontrar o usuário pelo email ou
         número 2 para encontrar o usuário pelo cpf
     id : str
-        identificador único (email ou cpf) do usuário que receberá um novo perfil.
+        Identificador único (email ou cpf) do usuário que receberá um novo perfil.
         Se id_cod for igual a 1, o id deve receber o email do usuário.
         Se id_cod for igual a 2, o id deve receber o cpf do usuário
     perfil : int
-        número do perfil que será adicionado ao usuário
+        Número do perfil que será adicionado ao usuário
     username : list[int]
-        lista de perfis já cadastrados do usuário que está usando o endpoint
+        Lista de perfis já cadastrados do usuário que está usando o endpoint
         para adicionar um perfil a outro usuário. Este dado é necessário para
         saber se quem está usando o endpoint tem permissão para modificar a
         lista de perfis de outra pessoa.
     acesso : int
-        perfil que tem permissão para gerir dados de outros usuários
+        Perfil que tem permissão para gerir dados de outros usuários
 
     Returns
     -------

--- a/app/controllers/usuarios/validacao_perfis_conflitantes.py
+++ b/app/controllers/usuarios/validacao_perfis_conflitantes.py
@@ -34,7 +34,7 @@ def validar_perfis_conflitantes(
     conflitos = set(perfis_cadastrados).intersection(perfis_conflitantes)
 
     if conflitos:
-        raise ValidationError(f"""
-        O perfil {novo_perfil} não pode ser adicionado pois os perfis
-        conflitantes {conflitos} já estão cadastrados
-        """)
+        raise ValidationError(
+            f"O perfil {novo_perfil} não pode ser adicionado pois os perfis "
+            f"conflitantes {conflitos} já estão cadastrados"
+        )

--- a/app/controllers/usuarios/validacao_perfis_conflitantes.py
+++ b/app/controllers/usuarios/validacao_perfis_conflitantes.py
@@ -1,0 +1,40 @@
+from typing import Iterable
+
+RELACAO_DE_CONFLITOS_POR_PERFIL = {
+    8: set([9]),
+    9: set([8])
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def validar_perfis_conflitantes(
+    novo_perfil: int,
+    perfis_cadastrados: Iterable,
+) -> None:
+    """Levanta um erro se houver perfis cadastrados que conflitam com o novo perfil
+
+    Parameters
+    ----------
+    novo_perfil : int
+        Número do novo perfil a ser cadastrado
+    perfis_cadastrados : Iterable
+        Iterável com números dos perfis já cadastrados
+
+    Raises
+    ------
+    ValidationError
+        Lança um ValidationError quando algum dos perfis cadastrados
+        é conflitante com o novo perfil a ser cadastrado
+    """
+
+    perfis_conflitantes = RELACAO_DE_CONFLITOS_POR_PERFIL.get(novo_perfil, set())
+    conflitos = set(perfis_cadastrados).intersection(perfis_conflitantes)
+
+    if conflitos:
+        raise ValidationError(f"""
+        O perfil {novo_perfil} não pode ser adicionado pois os perfis
+        conflitantes {conflitos} já estão cadastrados
+        """)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,10 @@ profile = "black"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ImpulsoGov/api-webapp"
+[tool.pytest.ini_options]
+pythonpath = [
+    "."
+]
+testpaths = [
+    "tests"
+]

--- a/tests/unit/usuarios/test_validar_perfis_conflitantes.py
+++ b/tests/unit/usuarios/test_validar_perfis_conflitantes.py
@@ -1,0 +1,95 @@
+import pytest
+from app.controllers.usuarios.validacao_perfis_conflitantes import (
+    validar_perfis_conflitantes,
+    ValidationError
+)
+
+PERFIS_CADASTRADOS = [1, 4]
+NOVO_PERFIL_SEM_RELACAO_DE_CONFLITOS = 3
+NOVO_PERFIL_COM_RELACAO_DE_CONFLITOS = 8
+LISTA_PERFIS_CADASTRADOS_NAO_ITERAVEIS = [1, 5.5]
+NOVOS_PERFIS_VS_NENHUM_PERFIL_CADASTRADO = [
+    (3, []),
+    (3, [None]),
+    (9, []),
+    (9, [None])
+]
+NOVOS_PERFIS_VS_CADASTRADOS_QUE_CONFLITAM = [
+    (8, [1, 9]),
+    (9, [8])
+]
+
+
+# Referências:
+# https://docs.pytest.org/en/7.1.x/how-to/assert.html#assertions-about-expected-exceptions
+# https://docs.pytest.org/en/7.1.x/example/parametrize.html
+@pytest.mark.parametrize(
+    "perfis_novos_com_relacao_de_conflito, perfis_cadastrados_que_conflitam_com_novo",
+    NOVOS_PERFIS_VS_CADASTRADOS_QUE_CONFLITAM
+)
+def test_erro_de_validacao_levantado_para_perfis_que_conflitam(
+    perfis_novos_com_relacao_de_conflito,
+    perfis_cadastrados_que_conflitam_com_novo
+):
+    """
+    Testa se ValidationError é levantado quando algum dos
+    perfis cadastrados conflita com o novo perfil
+    """
+    with pytest.raises(ValidationError):
+        validar_perfis_conflitantes(
+            novo_perfil=perfis_novos_com_relacao_de_conflito,
+            perfis_cadastrados=perfis_cadastrados_que_conflitam_com_novo
+        )
+
+
+# Referência:
+# https://miguendes.me/how-to-check-if-an-exception-is-raised-or-not-with-pytest
+def test_erro_de_validacao_nao_levantado_para_perfil_sem_conflito():
+    """
+    Testa se ValidationError não é levantado quando o novo
+    perfil não possui relação de conflito
+    """
+    try:
+        validar_perfis_conflitantes(
+            novo_perfil=NOVO_PERFIL_SEM_RELACAO_DE_CONFLITOS,
+            perfis_cadastrados=PERFIS_CADASTRADOS
+        )
+    except ValidationError:
+        assert False, "'validar_perfis_conflitantes' levantou um ValidationError"
+
+
+def test_erro_de_validacao_nao_levantado_para_perfil_que_tem_conflitos():
+    """
+    Testa se ValidationError não é levantado quando o novo
+    perfil possui relação de conflito, mas não possui
+    nenhum perfil conflitante cadastrado
+    """
+    try:
+        validar_perfis_conflitantes(
+            novo_perfil=NOVO_PERFIL_COM_RELACAO_DE_CONFLITOS,
+            perfis_cadastrados=PERFIS_CADASTRADOS
+        )
+    except ValidationError:
+        assert False, "'validar_perfis_conflitantes' levantou um ValidationError"
+
+
+@pytest.mark.parametrize(
+    "novo_perfil, nenhum_perfil_cadastrado",
+    NOVOS_PERFIS_VS_NENHUM_PERFIL_CADASTRADO
+)
+def test_erro_de_validacao_nao_levantado_quando_nao_ha_perfis_cadastrados(
+    novo_perfil,
+    nenhum_perfil_cadastrado
+):
+    """
+    Testa se ValidationError não é levantado quando não há perfis
+    cadastrados independente do novo perfil possuir
+    ou não relação de conflito
+    """
+    try:
+        validar_perfis_conflitantes(
+            novo_perfil=novo_perfil,
+            perfis_cadastrados=nenhum_perfil_cadastrado
+        )
+    except ValidationError:
+        assert False, "'validar_perfis_conflitantes' levantou um ValidationError"


### PR DESCRIPTION
### Descrição
O endpoint `/add-perfil` faz a adição novo perfil para usuários cadastrados e havia uma regra de negócio que não estava sendo aplicada nesse processo: não era validado se o novo perfil que seria adicionado conflitava com algum dos perfis já cadastrados do usuário, interrompendo o prosseguimento do processo caso houvesse conflito.

Dessa forma, algum usuário poderia acabar possuindo, simultaneamente, perfis que não deveriam ser aplicados à mesma pessoa ao mesmo tempo.

### Objetivos
- Adicionar validação de perfis conflitantes no endpoint `/add-perfil`
- Fazer testes unitários para a função de validação dos perfis conflitantes
<!--- - Fazer teste unitário dos perfis conflitantes no controller `add_perfil` -->

### Para executar os testes
Insira o comando no terminal:
```
pytest caminho/do/arquivo_de_teste.py
```
⚠️ **Para conseguir executar o pytest, é preciso fazer a instalação das dependências do dev-requirements.txt**

### Observações
A função de validação dos perfis conflitantes foi definida num arquivo próprio para ela porque, quando ela era definida no controller de gerenciamento de usuários, a execução dos testes demorava aproximadamente 15s.

Aparentemente isso ocorria porque o controller de gerenciamento de usuários possui muitas importações de módulos e definições de funções. Quando a função foi movida para um arquivo próprio, o tempo de execução dos testes caiu para alguns centésimos de segundo.
