### PR TITLE
[Indicadores de desempenho] Ordena dados por periodo_codigo ASC

### DIFF
--- a/app/controllers/impulso_previne_publico/indicadores_desempenho_score_equipes_validas.py
+++ b/app/controllers/impulso_previne_publico/indicadores_desempenho_score_equipes_validas.py
@@ -14,6 +14,7 @@ def consultar_indicadores_desempenho(municipio_uf):
         return (
             session.query(IndicadoresDesempenho)
             .filter_by(municipio_uf=municipio_uf)
+            .order_by(IndicadoresDesempenho.periodo_codigo)
             .all()
         )
     except Exception as error:


### PR DESCRIPTION
### Descrição
A tabela de Indicadores de desempenho, na [área aberta do Impulso Previne](https://www.impulsoprevine.org/dadoPublicos?painel=0), não estava exibindo os dados do último quadrimestre disponível, diferindo da informação no título da tabela.

### Objetivos
- Ordenar os dados do endpoint `/impulsoprevine/indicadores/desempenho_score_equipes_validas` pelo campo `periodo_codigo` ASC para que o acesso do último quadrimestre disponível no front-end seja feito corretamente

### Checklist de validação
- [ ] A requisição GET `/impulsoprevine/indicadores/desempenho_score_equipes_validas?municipio_uf=João Pessoa - PB` retorna os dados em ordem crescente pelo campo `periodo_codigo`