### PR TITLE
[Gestão de usuários lotes] Atualiza municipio_id_sus 

### DIFF
--- a/app/controllers/usuarios/cadastro_usuarios.py
+++ b/app/controllers/usuarios/cadastro_usuarios.py
@@ -553,7 +553,3 @@ def cadastrar_em_lote_sem_ativacao(
     except ValidationError as error:
         session.rollback()
         raise HTTPException(status_code=400, detail=str(error))
-    except Exception as error:
-        session.rollback()
-        print({"error": str(error)})
-        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/app/controllers/usuarios/cadastro_usuarios.py
+++ b/app/controllers/usuarios/cadastro_usuarios.py
@@ -118,15 +118,17 @@ def validar_se_municipio_corresponde_ao_id_sus(nome_uf: str, id_sus: str):
                 municipios.Municipios.municipio_nome,
                 " - ",
                 municipios.Municipios.estado_sigla,
-            ).__eq__(nome_uf),
-            municipios.Municipios.municipio_id_sus == id_sus,
+            ).__eq__(nome_uf)
         )
         .first()
     )
 
     if municipio is None:
+        raise ValidationError(f"Município {nome_uf} não existe na base de dados")
+
+    if municipio.municipio_id_sus != id_sus:
         raise ValidationError(
-            "Nome - UF do município e municipio_id_sus não são correspondentes"
+            f"Município {nome_uf} e ID SUS {id_sus} não são correspondentes"
         )
 
 

--- a/app/controllers/usuarios/cadastro_usuarios.py
+++ b/app/controllers/usuarios/cadastro_usuarios.py
@@ -6,10 +6,7 @@ from fastapi import HTTPException
 from passlib.context import CryptContext
 from validate_docbr import CPF
 
-from app.models import (
-    db,
-    municipios
-)
+from app.models import db, municipios
 from app.models.usuarios import (
     usuarios,
     perfil_acesso,
@@ -30,15 +27,22 @@ session = db.session
 
 
 def validar_senha(senha):
-    restricoes =[]
-    if len(senha)<8: restricoes.append({"mensagem1":"Senha deve conter ao menos 8 caracteres"})
-    if len(re.findall('[a-z]', senha))==0: restricoes.append({"mensagem2":"Senha deve conter letras minusculas"})
-    if len(re.findall('[A-Z]', senha))==0: restricoes.append({"mensagem3":"Senha deve conter letras maiusculas"})
-    if len(re.findall('[0-9]', senha))==0: restricoes.append({"mensagem4":"Senha deve conter numeros"})
-    if len(re.findall('\W', senha))==0: restricoes.append({"mensagem4":"Senha deve conter caracteres especiais"})
-    if len(re.findall('\s', senha))!=0: restricoes.append({"mensagem4":"Senha não deve conter espaços e quebras"})
-    validacao=True if len(restricoes)==0 else False
-    return restricoes,validacao
+    restricoes = []
+    if len(senha) < 8:
+        restricoes.append({"mensagem1": "Senha deve conter ao menos 8 caracteres"})
+    if len(re.findall("[a-z]", senha)) == 0:
+        restricoes.append({"mensagem2": "Senha deve conter letras minusculas"})
+    if len(re.findall("[A-Z]", senha)) == 0:
+        restricoes.append({"mensagem3": "Senha deve conter letras maiusculas"})
+    if len(re.findall("[0-9]", senha)) == 0:
+        restricoes.append({"mensagem4": "Senha deve conter numeros"})
+    if len(re.findall("\W", senha)) == 0:
+        restricoes.append({"mensagem4": "Senha deve conter caracteres especiais"})
+    if len(re.findall("\s", senha)) != 0:
+        restricoes.append({"mensagem4": "Senha não deve conter espaços e quebras"})
+    validacao = True if len(restricoes) == 0 else False
+    return restricoes, validacao
+
 
 def consulta_mail(email):
     try:
@@ -418,9 +422,7 @@ def ativar_perfil(id_cod, id):
         session.query(usuarios.Usuario).filter_by(**id_db).update(
             {
                 "perfil_ativo": True,
-                "atualizacao_data": datetime.now().strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                ),
+                "atualizacao_data": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             }
         )
         session.commit()

--- a/app/controllers/usuarios/cadastro_usuarios.py
+++ b/app/controllers/usuarios/cadastro_usuarios.py
@@ -180,7 +180,6 @@ def cadastrar_usuario_ip(municipio, cargo, telefone, whatsapp, mail, equipe):
     wp = True if whatsapp == "1" else False
     try:
         id_usuario = obter_id(mail)
-        print(id_usuario)
         # validar municipio
         # validar cargo
         # formato telefone
@@ -229,8 +228,6 @@ def cadastro_impulso(nome, mail, senha, cpf):
             return verifica_mail(mail)
         if consulta_mail(mail) != True:
             return consulta_mail(mail)
-        print(consulta_cpf(cpf) != True)
-        print(consulta_cpf(cpf))
         if consulta_cpf(cpf) != True:
             return {"mensagem": "CPF invalido", "error": True}
 
@@ -264,8 +261,6 @@ def cadastro_impulso_sem_ativacao(nome, mail, cpf):
             return verifica_mail(mail)
         if consulta_mail(mail) != True:
             return consulta_mail(mail)
-        print(consulta_cpf(cpf) != True)
-        print(consulta_cpf(cpf))
         if consulta_cpf(cpf) != True:
             return {"mensagem": "CPF invalido", "error": True}
 
@@ -361,11 +356,7 @@ def liberar_acesso(id_cod, id, perfil):
     # informar perfil liberado
     try:
         id_db = {"mail": id} if id_cod == 1 else {"cpf": id}
-        print("-----------------00000000000000000000000")
-        print(id_cod, id, perfil)
         res = session.query(usuarios.Usuario).filter_by(**id_db).all()
-        print("-------------------------")
-        print(res)
     except InternalError as error:
         if "municipio_id_sus" in error._message():
             raise ValidationError(
@@ -377,7 +368,6 @@ def liberar_acesso(id_cod, id, perfil):
         print({"error": error})
         return error
     try:
-        print("---------------------------------------------------------")
         if res[0].perfil_ativo != None:
             return {"mensagem": "Usuário já passou pela primeira liberação de perfil"}
         usuario_id = session.query(usuarios.Usuario).filter_by(**id_db).all()[0].id
@@ -451,7 +441,6 @@ def cadastrar_em_lote(
     if controle != True:
         return controle
     cad_impulso = cadastro_impulso(nome, mail, senha, cpf)
-    print(cad_impulso)
     etapas = []
     if cad_impulso["error"] == None:
         cad_ip = cadastro_ip(municipio_uf, cargo, telefone, whatsapp, mail, equipe)

--- a/app/controllers/usuarios/cadastro_usuarios.py
+++ b/app/controllers/usuarios/cadastro_usuarios.py
@@ -553,3 +553,7 @@ def cadastrar_em_lote_sem_ativacao(
     except ValidationError as error:
         session.rollback()
         raise HTTPException(status_code=400, detail=str(error))
+    except Exception as error:
+        session.rollback()
+        print({"error": str(error)})
+        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/app/routers/usuarios.py
+++ b/app/routers/usuarios.py
@@ -155,8 +155,7 @@ async def cadastro_lotes(
     perfil: str = Form(...),
     projeto: Optional[str] = Form("IP"),
     unidade_saude: Optional[str] = Form(None),
-    municipio_id_ibge: Optional[str] = Form(None),
-    municipio_id_sus: Optional[str] = Form(None),
+    municipio_id_sus: str = Form(...),
     username: Usuario = Depends(auth.get_current_user),
 ):
     return cadastro_usuarios.cadastrar_em_lote_sem_ativacao(
@@ -173,7 +172,6 @@ async def cadastro_lotes(
         perfil=perfil,
         projeto=projeto,
         unidade_saude=unidade_saude,
-        municipio_id_ibge=municipio_id_ibge,
         municipio_id_sus=municipio_id_sus,
     )
 

--- a/app/routers/usuarios.py
+++ b/app/routers/usuarios.py
@@ -156,6 +156,7 @@ async def cadastro_lotes(
     projeto: Optional[str] = Form("IP"),
     unidade_saude: Optional[str] = Form(None),
     municipio_id_ibge: Optional[str] = Form(None),
+    municipio_id_sus: Optional[str] = Form(None),
     username: Usuario = Depends(auth.get_current_user),
 ):
     return cadastro_usuarios.cadastrar_em_lote_sem_ativacao(
@@ -173,6 +174,7 @@ async def cadastro_lotes(
         projeto=projeto,
         unidade_saude=unidade_saude,
         municipio_id_ibge=municipio_id_ibge,
+        municipio_id_sus=municipio_id_sus,
     )
 
 

--- a/app/routers/usuarios.py
+++ b/app/routers/usuarios.py
@@ -143,7 +143,7 @@ async def cadastro_lotes(
 
 
 @router.post("/suporte/usuarios/cadastro-lote-sem-ativacao")
-async def cadastro_lotes(
+async def cadastro_lotes_sem_ativacao(
     nome: str = Form(...),
     mail: str = Form(...),
     cpf: str = Form(...),

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -1,0 +1,2 @@
+class ValidationError(Exception):
+    pass


### PR DESCRIPTION
### Descrição
Com a adição do campo `municipio_id_sus`  como um dos dados de usuário, houve a necessidade de que esse campo fosse alterado durante cadastro de usuários para que correspondesse corretamente ao município do mesmo.

### Objetivos
- Atualizar campo `municipio_id_sus` ao fazer requisições ao endpoint POST `/suporte/usuarios/cadastro-lote-sem-ativacao`
- Adicionar validação dos campos `municipio_uf` e `municipio_id_sus` para evitar cadastro de dados inválidos ou não referenciados na base de dados

### Checklist de validação
- ⚠️ Para validar as alterações, execute a API localmente a partir dessa branch conectando-a ao banco de homologação para não ferir a integridade dos dados de produção
- [ ] Não é possível cadastrar um novo usuário sem passar o campo `municipio_id_sus` na requisição
- [ ] A API retorna status 400 (BAD REQUEST) ao tentar cadastrar usuário cujo `municipio_uf` não está presente no banco
- [ ] A API retorna status 400 (BAD REQUEST) ao tentar cadastrar usuário cujo `municipio_uf` e `municipio_id_sus` não são correspondentes 
- [ ] O campo `municipio_id_sus` do usuário cadastrado é preenchido corretamente ao fazer uma requisição bem sucedida à API